### PR TITLE
Fix error on empty gnucash transactions

### DIFF
--- a/src/gnucash_to_beancount/directives.py
+++ b/src/gnucash_to_beancount/directives.py
@@ -2,6 +2,7 @@
 """
 from beancount.core import data
 from beancount.core.account_types import DEFAULT_ACCOUNT_TYPES as ACCOUNT_TYPES
+from decimal import DecimalException
 
 __author__ = "Henrique Bastos <henrique@bastos.net>"
 __license__ = "GNU GPLv2"
@@ -107,7 +108,10 @@ def price_for(split):
     if acc_comm == txn_comm:
         return None
 
-    number = abs(split.value / split.quantity)
+    try:
+        number = abs(split.value / split.quantity)
+    except DecimalException:  # handle empty transactions
+        return None
     currency = txn_comm.mnemonic
 
     return data.Amount(number, currency)


### PR DESCRIPTION
This pull request fixes #4 and possibly resolves #2. 

Adds an empty transaction in Beancount's ledger format for the equivalent empty Gnucash transaction. Earlier was raising exception when trying to deal with empty transaction by attempting to carry out a `0/0` invalid operation in the `directives.py:price_for()` function

Tested while exporting my Gnucash account to Beancount. Passes test.sh. 