### PR TITLE
Adapt API for a more recent Piecash.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 beancount==2.0b13
-piecash==0.11.1
+piecash==0.18.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
           keywords=['beancount', 'gnucash', 'convert', 'converter', 'ledger', 'accounting'],
           install_requires=[
               'beancount',
-              'piecash',
+              'piecash>=0.15.0',
           ],
           packages=find_packages(where='src'),
           package_dir={"": "src"},

--- a/src/gnucash_to_beancount/convert.py
+++ b/src/gnucash_to_beancount/convert.py
@@ -13,7 +13,7 @@ __license__ = "GNU GPLv2"
 
 
 def load_entries(book):
-    first_date = book.transactions[0].post_date.date()
+    first_date = book.transactions[0].post_date
 
     entries = []
 

--- a/src/gnucash_to_beancount/directives.py
+++ b/src/gnucash_to_beancount/directives.py
@@ -79,7 +79,7 @@ def Commodity(commodity, date):
 
 def Price(price):
     meta = {}
-    date = price.date.date()
+    date = price.date
     currency = price.commodity.mnemonic
     amount = data.Amount(price.value, price.currency.mnemonic)
 
@@ -126,7 +126,7 @@ def Posting(split):
 
 def Transaction(txn, postings=None):
     meta = meta_from(txn, 'num notes')
-    date = txn.post_date.date()
+    date = txn.post_date
     flag = '*'
     payee = ''
     narration = txn.description


### PR DESCRIPTION
Expect dates as 'date', rather than 'datetime', to track
changes in Piecash 0.15.0.